### PR TITLE
Updating rbnacl to current version.  Tests pass, so should be good.

### DIFF
--- a/easy_encryption.gemspec
+++ b/easy_encryption.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.1.0"
   spec.add_development_dependency "rspec", "~> 2.14.1"
-  spec.add_dependency "rbnacl", "~> 3.0.0"
+  spec.add_dependency "rbnacl", "~> 5.0.0"
 end

--- a/lib/easy_encryption/version.rb
+++ b/lib/easy_encryption/version.rb
@@ -1,3 +1,3 @@
 module EasyEncryption
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION

easy encryption was tied to a very old version of rbnacl that was causing error messages regarding using Mutex instead of Thread.exclusive.  This update to the current version of rbnacl should fix that problem.